### PR TITLE
Concatenate RUN commands to increase build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM php:7.0.2-fpm
 
 COPY config/custom.ini /usr/local/etc/php/conf.d/
 
-RUN apt-get update && apt-get install -y zlib1g-dev libicu-dev libpq-dev
-RUN docker-php-ext-install opcache
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install pdo_pgsql
-RUN pecl install apcu && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini
+RUN apt-get update && apt-get install -y zlib1g-dev libicu-dev libpq-dev \
+    && docker-php-ext-install opcache \
+    && docker-php-ext-install intl \
+    && docker-php-ext-install pdo_mysql \
+    && docker-php-ext-install pdo_pgsql \
+    && pecl install apcu \
+    && docker-php-ext-enable apcu


### PR DESCRIPTION
Also replaces `echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini`
with `docker-php-ext-enable apcu`.
