### PR TITLE
Set PHP error reporting optimized for production

### DIFF
--- a/config/custom.ini
+++ b/config/custom.ini
@@ -2,6 +2,14 @@
 
 date.timezone = "UTC"
 
+; Error reporting optimized for production (http://www.phptherightway.com/#error_reporting)
+
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL
+log_errors = On
+error_log = /var/log/php-app/error.log
+
 ; Opcache settings (best on https://www.scalingphpbook.com/best-zend-opcache-settings-tuning-config/)
 
 opcache.revalidate_freq = 0


### PR DESCRIPTION
@bakura10 this prevents PHP to output any errors and configures error logging to EB log